### PR TITLE
Allowing user to choose when to install update

### DIFF
--- a/template/src/squirrel-updater.js
+++ b/template/src/squirrel-updater.js
@@ -98,14 +98,8 @@ SquirrelUpdater.prototype.checkForUpdates = function() {
         if (error != null) {
           return;
         }
-        require('dialog').showMessageBox({type: "question", message: "Update available, would you like to restart and install now?", buttons: ["No", "Yes"]}, function(response){
-          if (response != 0) {
-            quitAndInstall();
-          } else {
-            require('app').once('window-all-closed', function(){
-              quitAndInstall();
-            });
-          }
+        require('app').once('window-all-closed', function(){
+          quitAndInstall();
         });
       });
     };

--- a/template/src/squirrel-updater.js
+++ b/template/src/squirrel-updater.js
@@ -98,7 +98,15 @@ SquirrelUpdater.prototype.checkForUpdates = function() {
         if (error != null) {
           return;
         }
-        return quitAndInstall();
+        require('dialog').showMessageBox({type: "question", message: "Update available, would you like to restart and install now?", buttons: ["No", "Yes"]}, function(response){
+          if (response != 0) {
+            quitAndInstall();
+          } else {
+            require('app').once('window-all-closed', function(){
+              quitAndInstall();
+            });
+          }
+        });
       });
     };
   })(this));


### PR DESCRIPTION
It can be jarring to force an application restart on a user, especially if they're using a text-editor or something that requires saving of data.  This PR adds a prompt to ask the user if they would like to install the update now (or later).