### PR TITLE
Changed dir in build-package.js from . to ./src because it causes the…

### DIFF
--- a/template/accelerator/tasks/build-packages.js
+++ b/template/accelerator/tasks/build-packages.js
@@ -12,7 +12,7 @@ module.exports = function (grunt) {
     grunt.log.subhead('Building ' + buildOptions.applicationName + ' for ' + buildOptions.platform + ' platform(s)\n')
 
     options = {
-      dir: './',
+      dir: './src',
       name: buildOptions.applicationName,
       platform: buildOptions.platform,
       arch: buildOptions.arch,


### PR DESCRIPTION
script/build worked fine for me on OSX but in windows using either script/build (from git bash) or script/build.cmd from Command prompt built but produced as ~900MB build.   I was abled to fix this by changing the director targeted by electron-packager to 'src' instead of '.'  

For some reason my OSX builds work for fine either way.
I _think_ this is a bug, if I'm doing something dumb

Details
* I'm targeting win32/ia32.
* I run the scripts from the root directory of my project
* My windows build is Windows 7 running on Parralles.